### PR TITLE
Allow setting the 'errorformat' option for Ag.vim

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -32,9 +32,9 @@ function! ag#Ag(cmd, args)
   " Format, used to manage column jump
   if a:cmd =~# '-g$'
     let g:agformat="%f"
-  else
+  elseif !exists("g:format")
     let g:agformat="%f:%l:%c:%m"
-  end
+  endif
 
   let grepprg_bak=&grepprg
   let grepformat_bak=&grepformat


### PR DESCRIPTION
- this is used in parsing ag's output
- see `:h errorformat` for more info
- when this can't be set, then certain ag options cannot be used in
  `g:agprg` (you won't be able to jump to the matches because the quickfix
  list won't be populated correctly if they do)

I don't see an issue with forcing the `'errorformat'` when we're searching for files (especially because this is a  command the plugin provides), but we could wrap that too if you could somehow get different output when using the `-g` flag.
