### PR TITLE
Don't remove mappings when using a custom handler

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -6,11 +6,11 @@ if !exists("g:agprg")
 endif
 
 if !exists("g:ag_apply_qmappings")
-  let g:ag_apply_qmappings = !exists("g:ag_qhandler")
+  let g:ag_apply_qmappings = 0
 endif
 
 if !exists("g:ag_apply_lmappings")
-  let g:ag_apply_lmappings = !exists("g:ag_lhandler")
+  let g:ag_apply_lmappings = 0
 endif
 
 if !exists("g:ag_qhandler")


### PR DESCRIPTION
When changing `g:ag_*handler` it would only make sense to remove the
quickfix/location list mappings if the new handler didn't use one of
those lists.

Otherwise removing the mappings is (imo) a separate decision from
writing your own handler, so it would be best not to mix the two.
