### PR TITLE
Mapping message option

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -21,6 +21,10 @@ if !exists("g:ag_lhandler")
   let g:ag_lhandler="botright lopen"
 endif
 
+if !exists("g:ag_mapping_message")
+  let g:ag_mapping_message=1
+endif
+
 function! ag#Ag(cmd, args)
   " If no pattern is provided, search for the word under the cursor
   if empty(a:args)
@@ -92,7 +96,9 @@ function! ag#Ag(cmd, args)
       " <C-w>J                                              Slam the quickfix/location list window against the bottom edge
       " :exe printf(":normal %d\<lt>c-w>_", b:height)<CR>   Restore the quickfix/location list window's height from before we opened the match
 
-      echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
+      if g:ag_mapping_message && l:apply_mappings
+        echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
+      endif
     endif
   else
     echom 'No matches for "'.a:args.'"'

--- a/doc/ag.txt
+++ b/doc/ag.txt
@@ -106,6 +106,14 @@ window is opened, or what size it is.  Example: >
   let g:ag_qhandler="copen 20"
 <
 
+                                                       *g:ag_mapping_message*
+Whether or not to show the message explaining the extra mappings that are
+added to the results list this plugin populates.  This message is not shown if
+the mappings are not applied (see |g:ag_apply_qmappings| and
+|g:ag_apply_lmappings| for more info.  Default 1.  Example: >
+  let g:ag_mapping_message=0
+<
+
 ==============================================================================
 MAPPINGS                                                        *ag-mappings*
 


### PR DESCRIPTION
Add an option to suppress the message that describes the mappings added by this plugin. Also don't show the message when the mappings aren't applied.
