### PR TITLE
Don't show empty lists of matches

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -48,10 +48,16 @@ function! ag#Ag(cmd, args)
   endtry
 
   if a:cmd =~# '^l'
+    let l:match_count = len(getloclist())
+  else
+    let l:match_count = len(getqflist())
+  endif
+
+  if a:cmd =~# '^l' && l:match_count
     exe g:ag_lhandler
     let l:apply_mappings = g:ag_apply_lmappings
     let l:matches_window_prefix = 'l' " we're using the location list
-  else
+  elseif l:match_count
     exe g:ag_qhandler
     let l:apply_mappings = g:ag_apply_qmappings
     let l:matches_window_prefix = 'c' " we're using the quickfix window
@@ -65,27 +71,31 @@ function! ag#Ag(cmd, args)
 
   redraw!
 
-  if l:apply_mappings
-    nnoremap <silent> <buffer> go <CR><C-w><C-w>
-    nnoremap <silent> <buffer> h  <C-W><CR><C-w>K
-    nnoremap <silent> <buffer> H  <C-W><CR><C-w>K<C-w>b
-    nnoremap <silent> <buffer> o  <CR>
-    nnoremap <silent> <buffer> t  <C-w><CR><C-w>T
-    nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
-    nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
+  if l:match_count
+    if l:apply_mappings
+      nnoremap <silent> <buffer> go <CR><C-w><C-w>
+      nnoremap <silent> <buffer> h  <C-W><CR><C-w>K
+      nnoremap <silent> <buffer> H  <C-W><CR><C-w>K<C-w>b
+      nnoremap <silent> <buffer> o  <CR>
+      nnoremap <silent> <buffer> t  <C-w><CR><C-w>T
+      nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
+      nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
 
-    exe 'nnoremap <silent> <buffer> e <CR><C-w><C-w>:' . l:matches_window_prefix .'close<CR>'
-    exe 'nnoremap <silent> <buffer> q  :' . l:matches_window_prefix . 'close<CR>'
-    exe 'nnoremap <silent> <buffer> gv :let b:height=winheight(0)<CR><C-w><CR><C-w>H:' . l:matches_window_prefix . 'open<CR><C-w>J:exe printf(":normal %d\<lt>c-w>_", b:height)<CR>'
-    " Interpretation:
-    " :let b:height=winheight(0)<CR>                      Get the height of the quickfix/location list window
-    " <CR><C-w>                                           Open the current item in a new split
-    " <C-w>H                                              Slam the newly opened window against the left edge
-    " :copen<CR> -or- :lopen<CR>                          Open either the quickfix window or the location list (whichever we were using)
-    " <C-w>J                                              Slam the quickfix/location list window against the bottom edge
-    " :exe printf(":normal %d\<lt>c-w>_", b:height)<CR>   Restore the quickfix/location list window's height from before we opened the match
+      exe 'nnoremap <silent> <buffer> e <CR><C-w><C-w>:' . l:matches_window_prefix .'close<CR>'
+      exe 'nnoremap <silent> <buffer> q  :' . l:matches_window_prefix . 'close<CR>'
+      exe 'nnoremap <silent> <buffer> gv :let b:height=winheight(0)<CR><C-w><CR><C-w>H:' . l:matches_window_prefix . 'open<CR><C-w>J:exe printf(":normal %d\<lt>c-w>_", b:height)<CR>'
+      " Interpretation:
+      " :let b:height=winheight(0)<CR>                      Get the height of the quickfix/location list window
+      " <CR><C-w>                                           Open the current item in a new split
+      " <C-w>H                                              Slam the newly opened window against the left edge
+      " :copen<CR> -or- :lopen<CR>                          Open either the quickfix window or the location list (whichever we were using)
+      " <C-w>J                                              Slam the quickfix/location list window against the bottom edge
+      " :exe printf(":normal %d\<lt>c-w>_", b:height)<CR>   Restore the quickfix/location list window's height from before we opened the match
 
-    echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
+      echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
+    endif
+  else
+    echom 'No matches for "'.a:args.'"'
   endif
 endfunction
 


### PR DESCRIPTION
Fixes https://github.com/rking/ag.vim/issues/40

I don't think this needs to be an option, because I've added a message for when there aren't any matches.
