### PR TITLE
supress E119:Not enough arguments for function

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -52,7 +52,7 @@ function! ag#Ag(cmd, args)
   endtry
 
   if a:cmd =~# '^l'
-    let l:match_count = len(getloclist())
+    let l:match_count = len(getloclist(winnr()))
   else
     let l:match_count = len(getqflist())
   endif


### PR DESCRIPTION
ag 0.18.1
vim 7.4 MacOS X (unix) pached 1-133
