### PR TITLE
Don't clobber global grepprg

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -84,21 +84,22 @@ function! ag#Ag(cmd, args)
     let g:ag_format="%f:%l:%c:%m"
   endif
 
-  let l:grepprg_bak=&grepprg
-  let l:grepformat_bak=&grepformat
-  let l:t_ti_bak=&t_ti
-  let l:t_te_bak=&t_te
+  let l:grepprg_bak    = &l:grepprg
+  let l:grepformat_bak = &grepformat
+  let l:t_ti_bak       = &t_ti
+  let l:t_te_bak       = &t_te
+
   try
-    let &grepprg=g:ag_prg
-    let &grepformat=g:ag_format
+    let &l:grepprg  = g:ag_prg
+    let &grepformat = g:ag_format
     set t_ti=
     set t_te=
     silent! execute a:cmd . " " . escape(l:grepargs, '|')
   finally
-    let &grepprg=l:grepprg_bak
-    let &grepformat=l:grepformat_bak
-    let &t_ti=l:t_ti_bak
-    let &t_te=l:t_te_bak
+    let &l:grepprg  = l:grepprg_bak
+    let &grepformat = l:grepformat_bak
+    let &t_ti       = l:t_ti_bak
+    let &t_te       = l:t_te_bak
   endtry
 
   if a:cmd =~# '^l'

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -1,5 +1,10 @@
 " NOTE: You must, of course, install ag / the_silver_searcher
 
+if exists('g:autoloaded_ag')
+  finish
+endif
+let g:autoloaded_ag = 1
+
 " FIXME: Delete deprecated options below on or after 15-7 (6 months from when they were changed) {{{
 
 if exists("g:agprg")
@@ -61,6 +66,12 @@ endfunction
 function! ag#Ag(cmd, args)
   let l:ag_executable = get(split(g:ag_prg, " "), 0)
 
+  if a:cmd =~# '^l'
+    let l:using_loclist = 1
+  else
+    let l:using_loclist = 0
+  endif
+
   " Ensure that `ag` is installed
   if !executable(l:ag_executable)
     echoe "Ag command '" . l:ag_executable . "' was not found. Is the silver searcher installed and on your $PATH?"
@@ -102,13 +113,13 @@ function! ag#Ag(cmd, args)
     let &t_te       = l:t_te_bak
   endtry
 
-  if a:cmd =~# '^l'
+  if l:using_loclist
     let l:match_count = len(getloclist(winnr()))
   else
     let l:match_count = len(getqflist())
   endif
 
-  if a:cmd =~# '^l' && l:match_count
+  if l:using_loclist && l:match_count
     exe g:ag_lhandler
     let l:apply_mappings = g:ag_apply_lmappings
     let l:matches_window_prefix = 'l' " we're using the location list


### PR DESCRIPTION
`'grepprg'` is a buffer-local setting. We should only use the `&l` version, or else when we restore it after an `:Ag` command, we're disrupting the setting in other buffers.

It's surprising that `'grepprg'` is local and global, and `'grepformat'` is only global, so I guess we have no choice but to clobber it. Perhaps this could have it's uses: suppose you have a C program with some tests in shell (or cram, etc., like ag!), and you always use `ag` for `'grepprg'`. The same `'grepformat'` can work project-wide, but you might have an autocommand that makes `'grepprg'` use `ag --shell` for all files under the tests directory.

Anyway, it's kind of pathological, but we just shouldn't clobber a global setting when local can be used. I was working on something else when I made the small changes here, but that's going to warrant deeper review discussion when it's ready I think, so I went ahead and isolated these changes.