### PR TITLE
Fix for versions after 0.29

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -19,7 +19,7 @@ endif
 " Location of the ag utility
 if !exists("g:ag_prg")
   " --vimgrep (consistent output we can parse) is available from version  0.25.0+
-  if split(system("ag --version"), "[ \n\r\t]")[2] =~ '\d\+.[2-9][5-9]\(.\d\+\)\?'
+  if split(system("ag --version"), "[ \n\r\t]")[2] =~ '\d\+.\(\(2[5-9]\)\|\([3-9][0-9]\)\)\(.\d\+\)\?'
     let g:ag_prg="ag --vimgrep"
   else
     " --noheading seems odd here, but see https://github.com/ggreer/the_silver_searcher/issues/361


### PR DESCRIPTION
The regex used to check if the version is > 0.25 breaks for versions with format 0.AB.X where A > 2 and B < 5. This means that with the latest version of ag (0.30.0), the result formatting gets messed up.

The check is using [2-9][5-9] to check the middle number, so:
0.19.0 - fail
0.20.0 - fail
0.25.0 - pass
0.30.0 - fail (current version :()
0.31.0 - fail
0.35.0 - pass
0.40.0 - fail

The new regex is a little more complicated, but uses (2[5-9])|([3-9][0-9]).
0.19.0 - fail
0.20.0 - fail
0.25.0 - pass
0.30.0 - pass (current version :D)
0.31.0 - pass
0.35.0 - pass
0.40.0 - pass
