### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Vim has various ways of installing plugins, the standard way is in [the document
   cd ~/.vim/bundle && git clone https://github.com/rking/ag.vim ag && echo "set runtimepath^=~/.vim/bundle/ag" >> ~/.vimrc
   ```
 
-  Then open vim and rum `:helptags ~/.vim/bundle/ag/doc`.
+  Then open vim and run `:helptags ~/.vim/bundle/ag/doc`.
 
 ### Configuration ###
 


### PR DESCRIPTION
Fixed a small typo in the README. I'm assuming 'rum' is supposed to be 'run'