### PR TITLE
Do not show the split window if there are no matches.

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -169,11 +169,12 @@ function! ag#Ag(cmd, args)
         echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
       endif
     endif
-  else
-    echom 'No matches for "'.a:args.'"'
-    " Close the split window automatically:
+  else " Close the split window automatically:
     cclose
     lclose
+    echohl WarningMsg
+    echom 'No matches for "'.a:args.'"'
+    echohl None
   endif
 endfunction
 

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -171,6 +171,9 @@ function! ag#Ag(cmd, args)
     endif
   else
     echom 'No matches for "'.a:args.'"'
+    " Close the split window automatically:
+    cclose
+    lclose
   endif
 endfunction
 


### PR DESCRIPTION
It makes no sense to show an empty list when there are no matches. This pull request addresses this issue by having the split window automatically close when no matches are found. It also makes the "no matches" message more prominent by highlighting it.