### PR TITLE
Custom keymaps

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -55,6 +55,10 @@ if !exists("g:ag_mapping_message")
   let g:ag_mapping_message=1
 endif
 
+if !exists("g:ag_mapping_message_text")
+  let g:ag_mapping_message_text="ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
+endif
+
 if !exists("g:ag_working_path_mode")
     let g:ag_working_path_mode = 'c'
 endif
@@ -178,7 +182,7 @@ function! ag#Ag(cmd, args)
       exe l:ag_mapping_func
 
       if g:ag_mapping_message
-        echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
+        echom g:ag_mapping_message_text
       endif
     endif
   else

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -165,7 +165,7 @@ function! ag#Ag(cmd, args)
       " <C-w>J                                              Slam the quickfix/location list window against the bottom edge
       " :exe printf(":normal %d\<lt>c-w>_", b:height)<CR>   Restore the quickfix/location list window's height from before we opened the match
 
-      if g:ag_mapping_message && l:apply_mappings
+      if g:ag_mapping_message
         echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
       endif
     endif

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -43,6 +43,14 @@ if !exists("g:ag_lhandler")
   let g:ag_lhandler="botright lopen"
 endif
 
+if !exists("g:ag_qmapping_func")
+  let g:ag_qmapping_func="call ag#AgSetDefaultMappings('c')" " we're using the quickfix window
+endif
+
+if !exists("g:ag_lmapping_func")
+  let g:ag_lmapping_func="call ag#AgSetDefaultMappings('l')" " we're using the location list
+endif
+
 if !exists("g:ag_mapping_message")
   let g:ag_mapping_message=1
 endif
@@ -50,6 +58,28 @@ endif
 if !exists("g:ag_working_path_mode")
     let g:ag_working_path_mode = 'c'
 endif
+
+function! ag#AgSetDefaultMappings(matches_window_prefix)
+  nnoremap <silent> <buffer> h  <C-W><CR><C-w>K
+  nnoremap <silent> <buffer> H  <C-W><CR><C-w>K<C-w>b
+  nnoremap <silent> <buffer> o  <CR>
+  nnoremap <silent> <buffer> t  <C-w><CR><C-w>T
+  nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
+  nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
+
+  exe 'nnoremap <silent> <buffer> e <CR><C-w><C-w>:' . a:matches_window_prefix .'close<CR>'
+  exe 'nnoremap <silent> <buffer> go <CR>:' . a:matches_window_prefix . 'open<CR>'
+  exe 'nnoremap <silent> <buffer> q  :' . a:matches_window_prefix . 'close<CR>'
+
+  exe 'nnoremap <silent> <buffer> gv :let b:height=winheight(0)<CR><C-w><CR><C-w>H:' . a:matches_window_prefix . 'open<CR><C-w>J:exe printf(":normal %d\<lt>c-w>_", b:height)<CR>'
+  " Interpretation:
+  " :let b:height=winheight(0)<CR>                      Get the height of the quickfix/location list window
+  " <CR><C-w>                                           Open the current item in a new split
+  " <C-w>H                                              Slam the newly opened window against the left edge
+  " :copen<CR> -or- :lopen<CR>                          Open either the quickfix window or the location list (whichever we were using)
+  " <C-w>J                                              Slam the quickfix/location list window against the bottom edge
+  " :exe printf(":normal %d\<lt>c-w>_", b:height)<CR>   Restore the quickfix/location list window's height from before we opened the match
+endfunction
 
 function! ag#AgBuffer(cmd, args)
   let l:bufs = filter(range(1, bufnr('$')), 'buflisted(v:val)')
@@ -128,11 +158,11 @@ function! ag#Ag(cmd, args)
   if a:cmd =~# '^l' && l:match_count
     exe g:ag_lhandler
     let l:apply_mappings = g:ag_apply_lmappings
-    let l:matches_window_prefix = 'l' " we're using the location list
+    let l:ag_mapping_func = g:ag_lmapping_func
   elseif l:match_count
     exe g:ag_qhandler
     let l:apply_mappings = g:ag_apply_qmappings
-    let l:matches_window_prefix = 'c' " we're using the quickfix window
+    let l:ag_mapping_func = g:ag_qmapping_func
   endif
 
   " If highlighting is on, highlight the search keyword.
@@ -145,25 +175,7 @@ function! ag#Ag(cmd, args)
 
   if l:match_count
     if l:apply_mappings
-      nnoremap <silent> <buffer> h  <C-W><CR><C-w>K
-      nnoremap <silent> <buffer> H  <C-W><CR><C-w>K<C-w>b
-      nnoremap <silent> <buffer> o  <CR>
-      nnoremap <silent> <buffer> t  <C-w><CR><C-w>T
-      nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
-      nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
-
-      exe 'nnoremap <silent> <buffer> e <CR><C-w><C-w>:' . l:matches_window_prefix .'close<CR>'
-      exe 'nnoremap <silent> <buffer> go <CR>:' . l:matches_window_prefix . 'open<CR>'
-      exe 'nnoremap <silent> <buffer> q  :' . l:matches_window_prefix . 'close<CR>'
-
-      exe 'nnoremap <silent> <buffer> gv :let b:height=winheight(0)<CR><C-w><CR><C-w>H:' . l:matches_window_prefix . 'open<CR><C-w>J:exe printf(":normal %d\<lt>c-w>_", b:height)<CR>'
-      " Interpretation:
-      " :let b:height=winheight(0)<CR>                      Get the height of the quickfix/location list window
-      " <CR><C-w>                                           Open the current item in a new split
-      " <C-w>H                                              Slam the newly opened window against the left edge
-      " :copen<CR> -or- :lopen<CR>                          Open either the quickfix window or the location list (whichever we were using)
-      " <C-w>J                                              Slam the quickfix/location list window against the bottom edge
-      " :exe printf(":normal %d\<lt>c-w>_", b:height)<CR>   Restore the quickfix/location list window's height from before we opened the match
+      exe l:ag_mapping_func
 
       if g:ag_mapping_message
         echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"

--- a/doc/ag.txt
+++ b/doc/ag.txt
@@ -138,6 +138,18 @@ window is opened, or what size it is. Example: >
   let g:ag_qhandler="copen 20"
 <
 
+                                                           *g:ag_lmapping_func*
+A custom command used to set key mappings for the location list. Default:
+"call ag#AgSetDefaultMappings('l')". Example: >
+  let g:ag_qhandler="call AgSetMyCustomMappings()"
+<
+
+
+                                                           *g:ag_qmapping_func*
+A custom command used to set key mappings for the quickfix window. Default:
+"call ag#AgSetDefaultMappings('c')". Example: >
+  let g:ag_qhandler="call AgSetMyCustomMappings()"
+<
                                                          *g:ag_mapping_message*
 Whether or not to show the message explaining the extra mappings that are
 added to the results list this plugin populates. This message is not shown if
@@ -147,7 +159,7 @@ the mappings are not applied (see |g:ag_apply_qmappings| and
 <
 
 ==============================================================================
-MAPPINGS                                                         *ag-mappings*
+DEFAULT MAPPINGS                                                 *ag-mappings*
 
 The following keyboard shortcuts are available in the quickfix window:
 

--- a/doc/ag.txt
+++ b/doc/ag.txt
@@ -154,8 +154,16 @@ A custom command used to set key mappings for the quickfix window. Default:
 Whether or not to show the message explaining the extra mappings that are
 added to the results list this plugin populates. This message is not shown if
 the mappings are not applied (see |g:ag_apply_qmappings| and
-|g:ag_apply_lmappings| for more info. Default 1. Example: >
+|g:ag_apply_lmappings| for more info). Default 1. Example: >
   let g:ag_mapping_message=0
+<
+
+                                                    *g:ag_mapping_message_text*
+A custom message string to display when the results list window opens
+(see |g:ag_mapping_message| and for more info). Default "ag.vim keys: q=quit
+<cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same".
+Example: >
+  let g:ag_mapping_message="Press q to close results list"
 <
 
 ==============================================================================


### PR DESCRIPTION
It would be nice to be able to use the same keymaps from [ctrlp](https://github.com/kien/ctrlp.vim)'s fuzzy file search with ag.vim.

The current functionality is kept as the default.
