### PR TITLE
Allow using a `g:ag_max_line_len` option to truncate long lines

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -37,7 +37,7 @@ if !exists("g:ag_prg")
 endif
 
 " Use `cut` as the pager to truncate long lines if needed
-if g:ag_max_line_len
+if exists("g:ag_max_line_len") && has("unix")
   let g:ag_prg = g:ag_prg . " --pager 'cut -c1-" . g:ag_max_line_len . "'"
 endif
 

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -36,6 +36,11 @@ if !exists("g:ag_prg")
   endif
 endif
 
+" Use `cut` as the pager to truncate long lines if needed
+if g:ag_max_line_len
+  let g:ag_prg = g:ag_prg . " --pager 'cut -c1-" . g:ag_max_line_len . "'"
+endif
+
 if !exists("g:ag_apply_qmappings")
   let g:ag_apply_qmappings=1
 endif


### PR DESCRIPTION
Internally uses `cut` command as the pager when calling `ag` to stop long lines from ending up in your quickfix. 

Usage: 
In `.vimrc`

```
let g:ag_max_line_len = 200
```
