### PR TITLE
Highlight implicit (under cursor) search

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -151,7 +151,7 @@ function! ag#Ag(cmd, args)
 
   " If highlighting is on, highlight the search keyword.
   if exists('g:ag_highlight')
-    let @/ = matchstr(a:args, "\\v(-)\@<!(\<)\@<=\\w+|['\"]\\zs.{-}\\ze['\"]")
+    let @/ = matchstr(l:grepargs, "\\v(-)\@<!(\<)\@<=\\w+|['\"]\\zs.{-}\\ze['\"]")
     call feedkeys(":let &hlsearch=1 \| echo \<CR>", 'n')
   end
 


### PR DESCRIPTION
Previously `:Ag` would implicitly search for what was under the cursor, but not
highlight the search even if `let g:ag_highlight=1` was set.

Let me know if there is a better way to fix this!