### PR TITLE
Add user customizable function for searching for the project root.

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -57,7 +57,7 @@ if !exists("g:ag_mapping_message")
 endif
 
 if !exists("g:ag_working_path_mode")
-    let g:ag_working_path_mode = 'c'
+  let g:ag_working_path_mode = 'c'
 endif
 
 function! ag#AgBuffer(cmd, args)
@@ -114,17 +114,18 @@ function! ag#Ag(cmd, args)
     set t_te=
     if g:ag_working_path_mode ==? 'r' " Try to find the projectroot for current buffer
       let l:cwd_back = getcwd()
-      let l:cwd = s:guessProjectRoot()
+      let l:cwd = g:Ag_get_project_root()
       try
-        exe "lcd ".l:cwd
+        exe "lcd" l:cwd
+        echo 'Searching from' l:cwd
       catch
-        echom 'Failed to change directory to:'.l:cwd
+        echom 'Failed to change directory to' l:cwd
       finally
-        silent! execute a:cmd . " " . escape(l:grepargs, '|')
+        silent! execute a:cmd escape(l:grepargs, '|')
         exe "lcd ".l:cwd_back
       endtry
     else " Someone chose an undefined value or 'c' so we revert to the default
-      silent! execute a:cmd . " " . escape(l:grepargs, '|')
+      silent! execute a:cmd escape(l:grepargs, '|')
     endif
   finally
     let &grepprg=l:grepprg_bak
@@ -232,3 +233,9 @@ function! s:guessProjectRoot()
   " Nothing found, fallback to current working dir
   return getcwd()
 endfunction
+
+if !exists("g:Ag_get_project_root")
+  let g:Ag_get_project_root = function("s:guessProjectRoot")
+endif
+
+" vim:ts=2:sw=2:et

--- a/doc/ag.txt
+++ b/doc/ag.txt
@@ -94,9 +94,11 @@ For background, see: https://github.com/rking/ag.vim/pull/88
                                                        *g:ag_working_path_mode*
 A mapping that describes where ag will be run. Default is the current working
 directory. Specifying 'r' as the argument will tell it to run from the project
-rootdirectory. For now any other mapping will result to the default.
-Example:
+rootdirectory. For now any other mapping will result to the default. The
+function that specifies the root directory can be customized with
+|g:Ag_get_project_root|. Example: >
   let g:ag_working_path_mode='r'
+<
 
                                                                *g:ag_highlight*
 If 1, highlight the search terms after searching. Default: 0. Example: >
@@ -144,6 +146,13 @@ added to the results list this plugin populates. This message is not shown if
 the mappings are not applied (see |g:ag_apply_qmappings| and
 |g:ag_apply_lmappings| for more info. Default 1. Example: >
   let g:ag_mapping_message=0
+<
+
+                                                         *g:Ag_get_project_root*
+An alternative function to use when searching for the project root when
+|g:ag_working_path_mode| is set to 'r'. It should return the root directory
+from which ag will be executed. Example: >
+  let g:Ag_get_project_root=function("s:guessProjectRoot")
 <
 
 ==============================================================================

--- a/doc/ag.txt
+++ b/doc/ag.txt
@@ -95,7 +95,7 @@ For background, see: https://github.com/rking/ag.vim/pull/88
 A mapping that describes where ag will be run. Default is the current working
 directory. Specifying 'r' as the argument will tell it to run from the project
 rootdirectory. For now any other mapping will result to the default. The
-function that specifies the root directory can be customized with
+function that locates the root directory can be customized with
 |g:Ag_get_project_root|. Example: >
   let g:ag_working_path_mode='r'
 <


### PR DESCRIPTION
When `g:ag_working_path_mode` is `'r'`, this PR adds the allowance for a user to customize the function to be used to determine what the project root is. The default search looks up the directory hierarchy for a fixed list of file and directory names which may not suit all users so those with special requirements can provide their own method.
