### PR TITLE
Adds customizable list of items to look for when searching for project root

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -57,7 +57,11 @@ if !exists("g:ag_mapping_message")
 endif
 
 if !exists("g:ag_working_path_mode")
-    let g:ag_working_path_mode = 'c'
+  let g:ag_working_path_mode = 'c'
+endif
+
+if !exists("g:ag_working_path_root_markers")
+  let g:ag_working_path_root_markers = ['.rootdir', '.git', '.hg', '.svn', 'bzr', '_darcs', 'build.xml', 'tags', 'TAGS']
 endif
 
 function! ag#AgBuffer(cmd, args)
@@ -220,7 +224,7 @@ function! s:guessProjectRoot()
 
   while len(l:splitsearchdir) > 2
     let l:searchdir = '/'.join(l:splitsearchdir, '/').'/'
-    for l:marker in ['.rootdir', '.git', '.hg', '.svn', 'bzr', '_darcs', 'build.xml']
+    for l:marker in g:ag_working_path_root_markers
       " found it! Return the dir
       if filereadable(l:searchdir.l:marker) || isdirectory(l:searchdir.l:marker)
         return l:searchdir
@@ -232,3 +236,5 @@ function! s:guessProjectRoot()
   " Nothing found, fallback to current working dir
   return getcwd()
 endfunction
+
+" vim:ts=2:sw=2:et

--- a/doc/ag.txt
+++ b/doc/ag.txt
@@ -94,9 +94,17 @@ For background, see: https://github.com/rking/ag.vim/pull/88
                                                        *g:ag_working_path_mode*
 A mapping that describes where ag will be run. Default is the current working
 directory. Specifying 'r' as the argument will tell it to run from the project
-rootdirectory. For now any other mapping will result to the default.
-Example:
+rootdirectory. For now any other mapping will result to the default. Example: >
   let g:ag_working_path_mode='r'
+<
+
+                                               *g:ag_working_path_root_markers*
+A list of file and directory names to look for when |g:ag_working_path_mode|
+is 'r' and |g:Ag_get_project_root| is left at its default value. Default list
+is ['.rootdir', '.git', '.hg', '.svn', 'bzr', '_darcs', 'build.xml', 'tags', 'TAGS'].
+Example: >
+  let g:ag_working_path_root_markers = ['tags']
+<
 
                                                                *g:ag_highlight*
 If 1, highlight the search terms after searching. Default: 0. Example: >


### PR DESCRIPTION
Previous functionality added an optional hunt for project root so that the working directory would be changed to that root before starting `ag`. This facilitates searching the entire project. However, the list of items was hard coded so changing that list required locally modifying the plugin. This change moves the list of items into a global that can be overridden in the user's `.vimrc`. This change also adds the `tags` file as a default item that locates the project root.
