### PR TITLE
can not use "~/.vim/ag" as <custom-ag-path-goes-here>

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -73,7 +73,7 @@ function! ag#AgBuffer(cmd, args)
 endfunction
 
 function! ag#Ag(cmd, args)
-  let l:ag_executable = get(split(g:ag_prg, " "), 0)
+  let l:ag_executable = expand(get(split(g:ag_prg, " "), 0))
 
   " Ensure that `ag` is installed
   if !executable(l:ag_executable)


### PR DESCRIPTION
can not use "~/.vim/ag" as <custom-ag-path-goes-here>
